### PR TITLE
Avoid redundant writes

### DIFF
--- a/state.go
+++ b/state.go
@@ -68,6 +68,10 @@ func (st *StoredState) mutate(mutator func([]byte) ([]byte, error)) error {
 		return err
 	}
 
+	if bytes.Equal(mutated, cur) {
+		return nil
+	}
+
 	return st.ds.Put(st.name, mutated)
 }
 


### PR DESCRIPTION
Makes things quite a bit faster when restarting big miners, also avoids writing garbage to the write log